### PR TITLE
feat(tools): Add CLI tool integration framework

### DIFF
--- a/src/yolo_developer/config/__init__.py
+++ b/src/yolo_developer/config/__init__.py
@@ -19,16 +19,6 @@ from __future__ import annotations
 from yolo_developer.config.export import export_config, import_config
 from yolo_developer.config.loader import ConfigurationError, load_config
 from yolo_developer.config.schema import (
-    GateThreshold,
-    LLMConfig,
-    LLMProvider,
-    HybridConfig,
-    HybridRoutingConfig,
-    MemoryConfig,
-    OpenAIConfig,
-    QualityConfig,
-    SeedThresholdConfig,
-    YoloConfig,
     LLM_BEST_MODEL_DEFAULT,
     LLM_CHEAP_MODEL_DEFAULT,
     LLM_PREMIUM_MODEL_DEFAULT,
@@ -36,6 +26,19 @@ from yolo_developer.config.schema import (
     OPENAI_CODE_MODEL_DEFAULT,
     OPENAI_PREMIUM_MODEL_DEFAULT,
     OPENAI_REASONING_MODEL_DEFAULT,
+    CLIToolConfig,
+    CLIToolOutputFormat,
+    GateThreshold,
+    HybridConfig,
+    HybridRoutingConfig,
+    LLMConfig,
+    LLMProvider,
+    MemoryConfig,
+    OpenAIConfig,
+    QualityConfig,
+    SeedThresholdConfig,
+    ToolsConfig,
+    YoloConfig,
 )
 from yolo_developer.config.validators import (
     ValidationIssue,
@@ -44,6 +47,8 @@ from yolo_developer.config.validators import (
 )
 
 __all__ = [
+    "CLIToolConfig",
+    "CLIToolOutputFormat",
     "ConfigurationError",
     "GateThreshold",
     "LLMConfig",
@@ -61,6 +66,7 @@ __all__ = [
     "OPENAI_REASONING_MODEL_DEFAULT",
     "QualityConfig",
     "SeedThresholdConfig",
+    "ToolsConfig",
     "ValidationIssue",
     "ValidationResult",
     "YoloConfig",

--- a/src/yolo_developer/tools/__init__.py
+++ b/src/yolo_developer/tools/__init__.py
@@ -1,0 +1,36 @@
+"""External CLI tool integrations for YOLO Developer.
+
+This module provides interfaces for integrating with external CLI-based
+AI development tools like Claude Code and Aider.
+
+Example:
+    >>> from yolo_developer.tools import ClaudeCodeClient, ToolRegistry
+    >>> from yolo_developer.config import load_config
+    >>> config = load_config()
+    >>> registry = ToolRegistry(config.tools)
+    >>> claude = registry.get("claude_code")
+    >>> if claude:
+    ...     result = await claude.run("Analyze this code")
+"""
+
+from __future__ import annotations
+
+from yolo_developer.tools.base import (
+    BaseCLITool,
+    ToolDisabledError,
+    ToolError,
+    ToolNotFoundError,
+    ToolResult,
+)
+from yolo_developer.tools.claude_code import ClaudeCodeClient
+from yolo_developer.tools.registry import ToolRegistry
+
+__all__ = [
+    "BaseCLITool",
+    "ClaudeCodeClient",
+    "ToolDisabledError",
+    "ToolError",
+    "ToolNotFoundError",
+    "ToolRegistry",
+    "ToolResult",
+]

--- a/src/yolo_developer/tools/base.py
+++ b/src/yolo_developer/tools/base.py
@@ -1,0 +1,289 @@
+"""Base classes for external CLI tool integration.
+
+This module provides the abstract base class and result types for integrating
+with external CLI-based AI development tools like Claude Code and Aider.
+
+Example:
+    >>> from yolo_developer.tools.base import BaseCLITool, ToolResult
+    >>> class MyTool(BaseCLITool):
+    ...     @property
+    ...     def binary_name(self) -> str:
+    ...         return "mytool"
+    ...     def build_args(self, prompt: str, **kwargs) -> list[str]:
+    ...         return ["--prompt", prompt]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from yolo_developer.config import CLIToolConfig
+
+
+@dataclass
+class ToolResult:
+    """Result from CLI tool execution.
+
+    Attributes:
+        success: Whether the tool execution succeeded (exit code 0).
+        output: Raw stdout output from the tool.
+        parsed: Parsed JSON output if output_format is json and parsing succeeded.
+        exit_code: Process exit code (0 for success).
+        stderr: Raw stderr output from the tool.
+
+    Example:
+        >>> result = ToolResult(success=True, output='{"answer": 42}')
+        >>> result.success
+        True
+    """
+
+    success: bool
+    output: str
+    parsed: dict[str, Any] | None = None
+    exit_code: int = 0
+    stderr: str = ""
+
+
+@dataclass
+class ToolError:
+    """Error details from CLI tool execution.
+
+    Attributes:
+        code: Error code or category.
+        message: Human-readable error message.
+        details: Additional error context.
+
+    Example:
+        >>> error = ToolError(code="TIMEOUT", message="Tool timed out after 300s")
+    """
+
+    code: str
+    message: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+class ToolNotFoundError(FileNotFoundError):
+    """Raised when a CLI tool binary is not found in PATH."""
+
+    def __init__(self, binary_name: str, path: str | None = None) -> None:
+        self.binary_name = binary_name
+        self.path = path
+        if path:
+            msg = f"Tool binary not found at specified path: {path}"
+        else:
+            msg = f"Tool binary '{binary_name}' not found in PATH"
+        super().__init__(msg)
+
+
+class ToolDisabledError(RuntimeError):
+    """Raised when attempting to use a disabled tool."""
+
+    def __init__(self, tool_name: str) -> None:
+        self.tool_name = tool_name
+        super().__init__(f"Tool '{tool_name}' is disabled in configuration")
+
+
+class BaseCLITool(ABC):
+    """Abstract base class for external CLI tool integration.
+
+    Provides a common interface for wrapping CLI-based AI development tools.
+    Subclasses must implement `binary_name` and `build_args` methods.
+
+    Attributes:
+        config: Tool configuration from YoloConfig.
+        cwd: Working directory for tool execution.
+
+    Example:
+        >>> class ClaudeCode(BaseCLITool):
+        ...     @property
+        ...     def binary_name(self) -> str:
+        ...         return "claude"
+        ...     def build_args(self, prompt: str, **kwargs) -> list[str]:
+        ...         return ["--print", "--prompt", prompt]
+    """
+
+    def __init__(self, config: CLIToolConfig, cwd: str | None = None) -> None:
+        """Initialize the CLI tool wrapper.
+
+        Args:
+            config: Tool configuration from YoloConfig.tools.
+            cwd: Working directory for tool execution. Defaults to current directory.
+        """
+        self.config = config
+        self.cwd = cwd
+        self._binary_path: str | None = None
+
+    @property
+    @abstractmethod
+    def binary_name(self) -> str:
+        """Name of the CLI binary to execute.
+
+        Returns:
+            The binary name (e.g., "claude", "aider").
+        """
+        ...
+
+    @property
+    def binary_path(self) -> str:
+        """Resolved path to the CLI binary.
+
+        Uses configured path if set, otherwise searches PATH.
+
+        Returns:
+            Full path to the binary.
+
+        Raises:
+            ToolNotFoundError: If the binary is not found.
+        """
+        if self._binary_path is None:
+            if self.config.path:
+                self._binary_path = self.config.path
+            else:
+                found = shutil.which(self.binary_name)
+                if found is None:
+                    raise ToolNotFoundError(self.binary_name)
+                self._binary_path = found
+        return self._binary_path
+
+    @property
+    def is_available(self) -> bool:
+        """Check if the tool binary is available.
+
+        Returns:
+            True if the binary exists and is executable.
+        """
+        try:
+            _ = self.binary_path
+            return True
+        except ToolNotFoundError:
+            return False
+
+    @abstractmethod
+    def build_args(self, prompt: str, **kwargs: Any) -> list[str]:
+        """Build command-line arguments for the tool.
+
+        Args:
+            prompt: The prompt or task to send to the tool.
+            **kwargs: Additional options for argument building.
+
+        Returns:
+            List of command-line arguments (excluding the binary itself).
+        """
+        ...
+
+    async def run(self, prompt: str, **kwargs: Any) -> ToolResult:
+        """Execute the CLI tool with the given prompt.
+
+        Args:
+            prompt: The prompt or task to send to the tool.
+            **kwargs: Additional options passed to build_args.
+
+        Returns:
+            ToolResult with execution outcome.
+
+        Note:
+            Returns a failed ToolResult instead of raising exceptions
+            for runtime errors (timeout, execution failure). Only raises
+            ToolDisabledError if the tool is disabled in config.
+        """
+        if not self.config.enabled:
+            return ToolResult(
+                success=False,
+                output="",
+                exit_code=-1,
+                stderr=f"Tool '{self.binary_name}' is disabled in configuration",
+            )
+
+        try:
+            binary = self.binary_path
+        except ToolNotFoundError as e:
+            return ToolResult(
+                success=False,
+                output="",
+                exit_code=-1,
+                stderr=str(e),
+            )
+
+        args = [binary, *self.build_args(prompt, **kwargs)]
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                cwd=self.cwd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=self.config.timeout,
+            )
+        except TimeoutError:
+            return ToolResult(
+                success=False,
+                output="",
+                exit_code=-1,
+                stderr=f"Tool timed out after {self.config.timeout}s",
+            )
+        except OSError as e:
+            return ToolResult(
+                success=False,
+                output="",
+                exit_code=-1,
+                stderr=f"Failed to execute tool: {e}",
+            )
+
+        output = stdout.decode("utf-8", errors="replace")
+        stderr_str = stderr.decode("utf-8", errors="replace")
+
+        parsed = None
+        if self.config.output_format == "json" and proc.returncode == 0:
+            try:
+                parsed = json.loads(output)
+            except json.JSONDecodeError:
+                # Output wasn't valid JSON, leave parsed as None
+                pass
+
+        return ToolResult(
+            success=proc.returncode == 0,
+            output=output,
+            parsed=parsed,
+            exit_code=proc.returncode or 0,
+            stderr=stderr_str,
+        )
+
+    async def run_or_raise(self, prompt: str, **kwargs: Any) -> ToolResult:
+        """Execute the CLI tool, raising on failure.
+
+        Like run(), but raises exceptions for failures instead of
+        returning failed ToolResults.
+
+        Args:
+            prompt: The prompt or task to send to the tool.
+            **kwargs: Additional options passed to build_args.
+
+        Returns:
+            ToolResult with successful execution outcome.
+
+        Raises:
+            ToolDisabledError: If the tool is disabled.
+            ToolNotFoundError: If the binary is not found.
+            RuntimeError: If execution fails.
+        """
+        if not self.config.enabled:
+            raise ToolDisabledError(self.binary_name)
+
+        # This will raise ToolNotFoundError if not found
+        _ = self.binary_path
+
+        result = await self.run(prompt, **kwargs)
+
+        if not result.success:
+            raise RuntimeError(f"Tool execution failed (exit {result.exit_code}): {result.stderr}")
+
+        return result

--- a/src/yolo_developer/tools/claude_code.py
+++ b/src/yolo_developer/tools/claude_code.py
@@ -1,0 +1,250 @@
+"""Claude Code CLI integration.
+
+This module provides a client for integrating with Claude Code CLI,
+enabling YOLO Developer to delegate complex tasks to Claude Code.
+
+Example:
+    >>> from yolo_developer.config import CLIToolConfig
+    >>> from yolo_developer.tools.claude_code import ClaudeCodeClient
+    >>> config = CLIToolConfig(enabled=True, timeout=600)
+    >>> client = ClaudeCodeClient(config)
+    >>> result = await client.run("Analyze this codebase")
+    >>> if result.success:
+    ...     print(result.output)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from yolo_developer.tools.base import BaseCLITool, ToolResult
+
+
+class ClaudeCodeClient(BaseCLITool):
+    """Client for Claude Code CLI integration.
+
+    Wraps the Claude Code CLI to enable programmatic access to Claude Code's
+    capabilities including code analysis, implementation, and testing.
+
+    Example:
+        >>> from yolo_developer.config import CLIToolConfig
+        >>> config = CLIToolConfig(enabled=True, timeout=600)
+        >>> client = ClaudeCodeClient(config, cwd="/path/to/project")
+        >>> result = await client.implement("Add user authentication")
+    """
+
+    @property
+    def binary_name(self) -> str:
+        """Return the Claude Code binary name."""
+        return "claude"
+
+    def build_args(self, prompt: str, **kwargs: Any) -> list[str]:
+        """Build command-line arguments for Claude Code.
+
+        Args:
+            prompt: The prompt to send to Claude Code.
+            **kwargs: Additional options:
+                - plan_mode (bool): Enter plan mode for structured planning.
+                - resume (str): Session ID to resume.
+                - model (str): Model to use (e.g., "sonnet", "opus").
+                - allowedTools (list[str]): Restrict available tools.
+                - max_turns (int): Maximum conversation turns.
+
+        Returns:
+            List of command-line arguments.
+        """
+        args = ["--print"]
+
+        # Output format
+        if self.config.output_format == "json":
+            args.append("--output-format=json")
+
+        # Plan mode for structured implementation planning
+        if kwargs.get("plan_mode"):
+            args.append("--plan")
+
+        # Resume existing session
+        if kwargs.get("resume"):
+            args.extend(["--resume", kwargs["resume"]])
+
+        # Model selection
+        if kwargs.get("model"):
+            args.extend(["--model", kwargs["model"]])
+
+        # Tool restrictions
+        if kwargs.get("allowedTools"):
+            tools = kwargs["allowedTools"]
+            if isinstance(tools, list):
+                args.extend(["--allowedTools", ",".join(tools)])
+
+        # Max turns limit
+        if kwargs.get("max_turns"):
+            args.extend(["--max-turns", str(kwargs["max_turns"])])
+
+        # Add any extra args from config
+        args.extend(self.config.extra_args)
+
+        # Prompt must be last
+        args.extend(["--prompt", prompt])
+
+        return args
+
+    async def implement(
+        self,
+        task: str,
+        *,
+        plan_mode: bool = True,
+        context: str | None = None,
+        model: str | None = None,
+    ) -> ToolResult:
+        """Request implementation of a task.
+
+        Sends an implementation request to Claude Code, optionally using
+        plan mode for structured planning before execution.
+
+        Args:
+            task: Description of the task to implement.
+            plan_mode: Use plan mode for structured planning (default True).
+            context: Additional context to prepend to the task.
+            model: Model to use for this request.
+
+        Returns:
+            ToolResult with the implementation outcome.
+
+        Example:
+            >>> result = await client.implement(
+            ...     "Add user authentication with JWT tokens",
+            ...     plan_mode=True,
+            ... )
+        """
+        prompt = task
+        if context:
+            prompt = f"{context}\n\n{task}"
+
+        return await self.run(prompt, plan_mode=plan_mode, model=model)
+
+    async def analyze(
+        self,
+        query: str,
+        *,
+        scope: str | None = None,
+        model: str | None = None,
+    ) -> ToolResult:
+        """Request code analysis.
+
+        Sends an analysis request to Claude Code for understanding
+        code structure, patterns, or behavior.
+
+        Args:
+            query: The analysis question or request.
+            scope: Optional scope restriction (e.g., file paths, modules).
+            model: Model to use for this request.
+
+        Returns:
+            ToolResult with the analysis outcome.
+
+        Example:
+            >>> result = await client.analyze(
+            ...     "How is authentication implemented in this codebase?"
+            ... )
+        """
+        prompt = f"Analyze: {query}"
+        if scope:
+            prompt = f"{prompt}\n\nScope: {scope}"
+
+        return await self.run(prompt, model=model)
+
+    async def test(
+        self,
+        scope: str,
+        *,
+        fix_failures: bool = False,
+        model: str | None = None,
+    ) -> ToolResult:
+        """Run tests and analyze results.
+
+        Requests Claude Code to run tests for the specified scope
+        and report results.
+
+        Args:
+            scope: Test scope (e.g., file path, test name pattern).
+            fix_failures: Whether to attempt fixing failures.
+            model: Model to use for this request.
+
+        Returns:
+            ToolResult with test execution and analysis.
+
+        Example:
+            >>> result = await client.test(
+            ...     "tests/unit/config/",
+            ...     fix_failures=True,
+            ... )
+        """
+        if fix_failures:
+            prompt = f"Run tests for {scope}, analyze any failures, and fix them"
+        else:
+            prompt = f"Run tests for {scope} and report results"
+
+        return await self.run(prompt, model=model)
+
+    async def review(
+        self,
+        target: str,
+        *,
+        focus: str | None = None,
+        model: str | None = None,
+    ) -> ToolResult:
+        """Request code review.
+
+        Sends a code review request to Claude Code for the specified target.
+
+        Args:
+            target: What to review (e.g., file path, PR number, diff).
+            focus: Optional focus areas (e.g., "security", "performance").
+            model: Model to use for this request.
+
+        Returns:
+            ToolResult with review feedback.
+
+        Example:
+            >>> result = await client.review(
+            ...     "src/yolo_developer/tools/",
+            ...     focus="security and error handling",
+            ... )
+        """
+        prompt = f"Review: {target}"
+        if focus:
+            prompt = f"{prompt}\n\nFocus on: {focus}"
+
+        return await self.run(prompt, model=model)
+
+    async def refactor(
+        self,
+        target: str,
+        goal: str,
+        *,
+        plan_mode: bool = True,
+        model: str | None = None,
+    ) -> ToolResult:
+        """Request code refactoring.
+
+        Sends a refactoring request to Claude Code with a specific goal.
+
+        Args:
+            target: What to refactor (e.g., file path, function name).
+            goal: The refactoring goal or pattern to apply.
+            plan_mode: Use plan mode for structured planning (default True).
+            model: Model to use for this request.
+
+        Returns:
+            ToolResult with refactoring outcome.
+
+        Example:
+            >>> result = await client.refactor(
+            ...     "src/yolo_developer/config/loader.py",
+            ...     "Extract validation logic into separate functions",
+            ... )
+        """
+        prompt = f"Refactor {target}: {goal}"
+
+        return await self.run(prompt, plan_mode=plan_mode, model=model)

--- a/src/yolo_developer/tools/registry.py
+++ b/src/yolo_developer/tools/registry.py
@@ -1,0 +1,188 @@
+"""Tool registry for managing external CLI tools.
+
+This module provides a registry for lazily initializing and managing
+external CLI tool integrations.
+
+Example:
+    >>> from yolo_developer.config import load_config
+    >>> from yolo_developer.tools import ToolRegistry
+    >>> config = load_config()
+    >>> registry = ToolRegistry(config.tools)
+    >>> claude = registry.get("claude_code")
+    >>> if claude:
+    ...     result = await claude.run("Analyze this code")
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+from yolo_developer.tools.claude_code import ClaudeCodeClient
+
+if TYPE_CHECKING:
+    from yolo_developer.config import ToolsConfig
+    from yolo_developer.tools.base import BaseCLITool
+
+
+class ToolRegistry:
+    """Registry for external CLI tools.
+
+    Provides lazy initialization and lookup of CLI tool clients.
+    Tools are only instantiated when first requested.
+
+    Attributes:
+        config: Tools configuration from YoloConfig.
+        cwd: Working directory for tool execution.
+
+    Example:
+        >>> registry = ToolRegistry(config.tools, cwd="/path/to/project")
+        >>> if "claude_code" in registry.available():
+        ...     claude = registry.get("claude_code")
+        ...     result = await claude.run("What files are in this project?")
+    """
+
+    # Registry of known tool names to their client classes
+    _tool_classes: dict[str, type[BaseCLITool]] = {
+        "claude_code": ClaudeCodeClient,
+    }
+
+    def __init__(self, config: ToolsConfig, cwd: str | None = None) -> None:
+        """Initialize the tool registry.
+
+        Args:
+            config: Tools configuration from YoloConfig.tools.
+            cwd: Working directory for tool execution.
+        """
+        self.config = config
+        self.cwd = cwd
+        self._tools: dict[str, BaseCLITool] = {}
+
+    def get(self, name: str) -> BaseCLITool | None:
+        """Get a tool by name, lazily initializing if needed.
+
+        Only returns the tool if it is enabled in configuration.
+        Returns None if the tool is disabled or unknown.
+
+        Args:
+            name: Tool name (e.g., "claude_code", "aider").
+
+        Returns:
+            Tool client instance if enabled, None otherwise.
+
+        Example:
+            >>> claude = registry.get("claude_code")
+            >>> if claude:
+            ...     result = await claude.run("Analyze this code")
+        """
+        if name in self._tools:
+            return self._tools[name]
+
+        tool = self._create_tool(name)
+        if tool is not None:
+            self._tools[name] = tool
+
+        return tool
+
+    def _create_tool(self, name: str) -> BaseCLITool | None:
+        """Create a tool instance if enabled.
+
+        Args:
+            name: Tool name.
+
+        Returns:
+            Tool instance if enabled, None otherwise.
+        """
+        if name == "claude_code":
+            if self.config.claude_code.enabled:
+                return ClaudeCodeClient(self.config.claude_code, self.cwd)
+        elif name == "aider":
+            # Aider support can be added here when implemented
+            # if self.config.aider.enabled:
+            #     return AiderClient(self.config.aider, self.cwd)
+            pass
+
+        return None
+
+    def available(self) -> list[str]:
+        """List available (enabled) tools.
+
+        Returns:
+            List of tool names that are enabled in configuration.
+
+        Example:
+            >>> tools = registry.available()
+            >>> print(f"Available tools: {tools}")
+        """
+        tools: list[str] = []
+
+        if self.config.claude_code.enabled:
+            tools.append("claude_code")
+
+        if self.config.aider.enabled:
+            tools.append("aider")
+
+        return tools
+
+    def is_available(self, name: str) -> bool:
+        """Check if a specific tool is available.
+
+        A tool is available if it is enabled in configuration.
+
+        Args:
+            name: Tool name to check.
+
+        Returns:
+            True if the tool is enabled, False otherwise.
+
+        Example:
+            >>> if registry.is_available("claude_code"):
+            ...     claude = registry.get("claude_code")
+        """
+        return name in self.available()
+
+    def get_or_raise(self, name: str) -> BaseCLITool:
+        """Get a tool by name, raising if unavailable.
+
+        Args:
+            name: Tool name.
+
+        Returns:
+            Tool client instance.
+
+        Raises:
+            ValueError: If the tool is not available.
+
+        Example:
+            >>> try:
+            ...     claude = registry.get_or_raise("claude_code")
+            ... except ValueError as e:
+            ...     print(f"Tool not available: {e}")
+        """
+        tool = self.get(name)
+        if tool is None:
+            available = self.available()
+            if available:
+                msg = f"Tool '{name}' is not available. Available tools: {available}"
+            else:
+                msg = f"Tool '{name}' is not available. No tools are enabled."
+            raise ValueError(msg)
+        return tool
+
+    def __contains__(self, name: str) -> bool:
+        """Check if a tool is available using 'in' operator.
+
+        Example:
+            >>> if "claude_code" in registry:
+            ...     claude = registry.get("claude_code")
+        """
+        return self.is_available(name)
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over available tool names.
+
+        Example:
+            >>> for tool_name in registry:
+            ...     tool = registry.get(tool_name)
+        """
+        return iter(self.available())

--- a/tests/unit/tools/__init__.py
+++ b/tests/unit/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for tools package."""

--- a/tests/unit/tools/test_base.py
+++ b/tests/unit/tools/test_base.py
@@ -1,0 +1,337 @@
+"""Unit tests for tools base module (Issue #17)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from yolo_developer.config import CLIToolConfig
+from yolo_developer.tools.base import (
+    BaseCLITool,
+    ToolDisabledError,
+    ToolNotFoundError,
+    ToolResult,
+)
+
+
+class DummyTool(BaseCLITool):
+    """Dummy tool for testing BaseCLITool."""
+
+    @property
+    def binary_name(self) -> str:
+        return "dummy"
+
+    def build_args(self, prompt: str, **kwargs: Any) -> list[str]:
+        args = ["--prompt", prompt]
+        if kwargs.get("verbose"):
+            args.append("--verbose")
+        return args
+
+
+class TestToolResult:
+    """Tests for ToolResult dataclass."""
+
+    def test_tool_result_success(self) -> None:
+        """Verify ToolResult can represent success."""
+        result = ToolResult(success=True, output="Hello, world!")
+        assert result.success is True
+        assert result.output == "Hello, world!"
+        assert result.parsed is None
+        assert result.exit_code == 0
+        assert result.stderr == ""
+
+    def test_tool_result_failure(self) -> None:
+        """Verify ToolResult can represent failure."""
+        result = ToolResult(
+            success=False,
+            output="",
+            exit_code=1,
+            stderr="Error: command not found",
+        )
+        assert result.success is False
+        assert result.exit_code == 1
+        assert result.stderr == "Error: command not found"
+
+    def test_tool_result_with_parsed_json(self) -> None:
+        """Verify ToolResult can hold parsed JSON."""
+        result = ToolResult(
+            success=True,
+            output='{"answer": 42}',
+            parsed={"answer": 42},
+        )
+        assert result.parsed == {"answer": 42}
+
+
+class TestToolNotFoundError:
+    """Tests for ToolNotFoundError."""
+
+    def test_error_without_path(self) -> None:
+        """Verify error message when binary not in PATH."""
+        error = ToolNotFoundError("mytool")
+        assert error.binary_name == "mytool"
+        assert error.path is None
+        assert "mytool" in str(error)
+        assert "not found in PATH" in str(error)
+
+    def test_error_with_path(self) -> None:
+        """Verify error message when binary not at specified path."""
+        error = ToolNotFoundError("mytool", "/usr/bin/mytool")
+        assert error.binary_name == "mytool"
+        assert error.path == "/usr/bin/mytool"
+        assert "/usr/bin/mytool" in str(error)
+
+
+class TestToolDisabledError:
+    """Tests for ToolDisabledError."""
+
+    def test_error_message(self) -> None:
+        """Verify error message includes tool name."""
+        error = ToolDisabledError("claude")
+        assert error.tool_name == "claude"
+        assert "claude" in str(error)
+        assert "disabled" in str(error)
+
+
+class TestBaseCLITool:
+    """Tests for BaseCLITool abstract class."""
+
+    def test_init_with_defaults(self) -> None:
+        """Verify tool initialization with default config."""
+        config = CLIToolConfig(enabled=True)
+        tool = DummyTool(config)
+        assert tool.config == config
+        assert tool.cwd is None
+
+    def test_init_with_cwd(self) -> None:
+        """Verify tool initialization with custom cwd."""
+        config = CLIToolConfig(enabled=True)
+        tool = DummyTool(config, cwd="/tmp/project")
+        assert tool.cwd == "/tmp/project"
+
+    def test_binary_name_property(self) -> None:
+        """Verify binary_name is implemented by subclass."""
+        config = CLIToolConfig(enabled=True)
+        tool = DummyTool(config)
+        assert tool.binary_name == "dummy"
+
+    def test_build_args_basic(self) -> None:
+        """Verify build_args creates correct arguments."""
+        config = CLIToolConfig(enabled=True)
+        tool = DummyTool(config)
+        args = tool.build_args("test prompt")
+        assert args == ["--prompt", "test prompt"]
+
+    def test_build_args_with_kwargs(self) -> None:
+        """Verify build_args handles kwargs."""
+        config = CLIToolConfig(enabled=True)
+        tool = DummyTool(config)
+        args = tool.build_args("test prompt", verbose=True)
+        assert "--verbose" in args
+
+    def test_binary_path_with_config_path(self) -> None:
+        """Verify binary_path uses config path when set."""
+        config = CLIToolConfig(enabled=True, path="/custom/path/dummy")
+        tool = DummyTool(config)
+        assert tool.binary_path == "/custom/path/dummy"
+
+    def test_binary_path_not_found_raises(self) -> None:
+        """Verify binary_path raises when not in PATH."""
+        config = CLIToolConfig(enabled=True)
+        tool = DummyTool(config)
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(ToolNotFoundError) as exc_info:
+                _ = tool.binary_path
+            assert exc_info.value.binary_name == "dummy"
+
+    def test_binary_path_found_in_path(self) -> None:
+        """Verify binary_path finds binary in PATH."""
+        config = CLIToolConfig(enabled=True)
+        tool = DummyTool(config)
+        with patch("shutil.which", return_value="/usr/bin/dummy"):
+            assert tool.binary_path == "/usr/bin/dummy"
+
+    def test_is_available_true(self) -> None:
+        """Verify is_available returns True when binary found."""
+        config = CLIToolConfig(enabled=True, path="/usr/bin/dummy")
+        tool = DummyTool(config)
+        assert tool.is_available is True
+
+    def test_is_available_false(self) -> None:
+        """Verify is_available returns False when binary not found."""
+        config = CLIToolConfig(enabled=True)
+        tool = DummyTool(config)
+        with patch("shutil.which", return_value=None):
+            assert tool.is_available is False
+
+
+class TestBaseCLIToolRun:
+    """Tests for BaseCLITool.run() method."""
+
+    @pytest.mark.asyncio
+    async def test_run_disabled_tool(self) -> None:
+        """Verify run returns failure for disabled tool."""
+        config = CLIToolConfig(enabled=False)
+        tool = DummyTool(config)
+        result = await tool.run("test")
+        assert result.success is False
+        assert "disabled" in result.stderr
+
+    @pytest.mark.asyncio
+    async def test_run_binary_not_found(self) -> None:
+        """Verify run returns failure when binary not found."""
+        config = CLIToolConfig(enabled=True)
+        tool = DummyTool(config)
+        with patch("shutil.which", return_value=None):
+            result = await tool.run("test")
+            assert result.success is False
+            assert "not found" in result.stderr
+
+    @pytest.mark.asyncio
+    async def test_run_success(self) -> None:
+        """Verify run returns success on successful execution."""
+        config = CLIToolConfig(enabled=True, output_format="text")
+        tool = DummyTool(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"output", b""))
+        mock_proc.returncode = 0
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/dummy"),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+        ):
+            result = await tool.run("test prompt")
+            assert result.success is True
+            assert result.output == "output"
+            assert result.exit_code == 0
+
+    @pytest.mark.asyncio
+    async def test_run_failure(self) -> None:
+        """Verify run returns failure on non-zero exit."""
+        config = CLIToolConfig(enabled=True, output_format="text")
+        tool = DummyTool(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"", b"error message"))
+        mock_proc.returncode = 1
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/dummy"),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+        ):
+            result = await tool.run("test prompt")
+            assert result.success is False
+            assert result.exit_code == 1
+            assert result.stderr == "error message"
+
+    @pytest.mark.asyncio
+    async def test_run_timeout(self) -> None:
+        """Verify run handles timeout."""
+        config = CLIToolConfig(enabled=True, timeout=1)
+        tool = DummyTool(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(side_effect=TimeoutError)
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/dummy"),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+        ):
+            result = await tool.run("test prompt")
+            assert result.success is False
+            assert "timed out" in result.stderr
+
+    @pytest.mark.asyncio
+    async def test_run_json_parsing(self) -> None:
+        """Verify run parses JSON output when configured."""
+        config = CLIToolConfig(enabled=True, output_format="json")
+        tool = DummyTool(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b'{"result": "success"}', b""))
+        mock_proc.returncode = 0
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/dummy"),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+        ):
+            result = await tool.run("test prompt")
+            assert result.success is True
+            assert result.parsed == {"result": "success"}
+
+    @pytest.mark.asyncio
+    async def test_run_json_parsing_failure(self) -> None:
+        """Verify run handles invalid JSON gracefully."""
+        config = CLIToolConfig(enabled=True, output_format="json")
+        tool = DummyTool(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"not json", b""))
+        mock_proc.returncode = 0
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/dummy"),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+        ):
+            result = await tool.run("test prompt")
+            assert result.success is True
+            assert result.parsed is None
+            assert result.output == "not json"
+
+
+class TestBaseCLIToolRunOrRaise:
+    """Tests for BaseCLITool.run_or_raise() method."""
+
+    @pytest.mark.asyncio
+    async def test_run_or_raise_disabled(self) -> None:
+        """Verify run_or_raise raises for disabled tool."""
+        config = CLIToolConfig(enabled=False)
+        tool = DummyTool(config)
+        with pytest.raises(ToolDisabledError):
+            await tool.run_or_raise("test")
+
+    @pytest.mark.asyncio
+    async def test_run_or_raise_not_found(self) -> None:
+        """Verify run_or_raise raises for missing binary."""
+        config = CLIToolConfig(enabled=True)
+        tool = DummyTool(config)
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(ToolNotFoundError):
+                await tool.run_or_raise("test")
+
+    @pytest.mark.asyncio
+    async def test_run_or_raise_failure(self) -> None:
+        """Verify run_or_raise raises on execution failure."""
+        config = CLIToolConfig(enabled=True, output_format="text")
+        tool = DummyTool(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"", b"error"))
+        mock_proc.returncode = 1
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/dummy"),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                await tool.run_or_raise("test")
+            assert "exit 1" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_run_or_raise_success(self) -> None:
+        """Verify run_or_raise returns result on success."""
+        config = CLIToolConfig(enabled=True, output_format="text")
+        tool = DummyTool(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"output", b""))
+        mock_proc.returncode = 0
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/dummy"),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+        ):
+            result = await tool.run_or_raise("test")
+            assert result.success is True

--- a/tests/unit/tools/test_claude_code.py
+++ b/tests/unit/tools/test_claude_code.py
@@ -1,0 +1,309 @@
+"""Unit tests for Claude Code client (Issue #17)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from yolo_developer.config import CLIToolConfig
+from yolo_developer.tools.claude_code import ClaudeCodeClient
+
+
+class TestClaudeCodeClient:
+    """Tests for ClaudeCodeClient."""
+
+    def test_binary_name(self) -> None:
+        """Verify binary name is claude."""
+        config = CLIToolConfig(enabled=True)
+        client = ClaudeCodeClient(config)
+        assert client.binary_name == "claude"
+
+    def test_build_args_basic(self) -> None:
+        """Verify build_args creates correct basic arguments."""
+        config = CLIToolConfig(enabled=True, output_format="json")
+        client = ClaudeCodeClient(config)
+        args = client.build_args("test prompt")
+
+        assert "--print" in args
+        assert "--output-format=json" in args
+        assert "--prompt" in args
+        assert "test prompt" in args
+
+    def test_build_args_text_format(self) -> None:
+        """Verify build_args handles text output format."""
+        config = CLIToolConfig(enabled=True, output_format="text")
+        client = ClaudeCodeClient(config)
+        args = client.build_args("test prompt")
+
+        assert "--print" in args
+        assert "--output-format=json" not in args
+
+    def test_build_args_plan_mode(self) -> None:
+        """Verify build_args adds plan flag."""
+        config = CLIToolConfig(enabled=True)
+        client = ClaudeCodeClient(config)
+        args = client.build_args("test prompt", plan_mode=True)
+
+        assert "--plan" in args
+
+    def test_build_args_resume(self) -> None:
+        """Verify build_args adds resume flag."""
+        config = CLIToolConfig(enabled=True)
+        client = ClaudeCodeClient(config)
+        args = client.build_args("test prompt", resume="session-123")
+
+        assert "--resume" in args
+        assert "session-123" in args
+
+    def test_build_args_model(self) -> None:
+        """Verify build_args adds model flag."""
+        config = CLIToolConfig(enabled=True)
+        client = ClaudeCodeClient(config)
+        args = client.build_args("test prompt", model="opus")
+
+        assert "--model" in args
+        assert "opus" in args
+
+    def test_build_args_allowed_tools(self) -> None:
+        """Verify build_args adds allowedTools flag."""
+        config = CLIToolConfig(enabled=True)
+        client = ClaudeCodeClient(config)
+        args = client.build_args("test prompt", allowedTools=["Read", "Write", "Bash"])
+
+        assert "--allowedTools" in args
+        assert "Read,Write,Bash" in args
+
+    def test_build_args_max_turns(self) -> None:
+        """Verify build_args adds max-turns flag."""
+        config = CLIToolConfig(enabled=True)
+        client = ClaudeCodeClient(config)
+        args = client.build_args("test prompt", max_turns=5)
+
+        assert "--max-turns" in args
+        assert "5" in args
+
+    def test_build_args_extra_args(self) -> None:
+        """Verify build_args includes extra_args from config."""
+        config = CLIToolConfig(
+            enabled=True,
+            extra_args=["--dangerously-skip-permissions"],
+        )
+        client = ClaudeCodeClient(config)
+        args = client.build_args("test prompt")
+
+        assert "--dangerously-skip-permissions" in args
+
+    def test_build_args_prompt_is_last(self) -> None:
+        """Verify prompt is at the end of args."""
+        config = CLIToolConfig(enabled=True)
+        client = ClaudeCodeClient(config)
+        args = client.build_args("my prompt", plan_mode=True, model="sonnet")
+
+        # Find the position of --prompt
+        prompt_idx = args.index("--prompt")
+        assert prompt_idx == len(args) - 2
+        assert args[-1] == "my prompt"
+
+
+class TestClaudeCodeClientMethods:
+    """Tests for ClaudeCodeClient convenience methods."""
+
+    @pytest.mark.asyncio
+    async def test_implement_basic(self) -> None:
+        """Verify implement method calls run with plan mode."""
+        config = CLIToolConfig(enabled=True)
+        client = ClaudeCodeClient(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"output", b""))
+        mock_proc.returncode = 0
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
+        ):
+            result = await client.implement("Add authentication")
+
+            assert result.success is True
+            # Verify plan mode is enabled by default
+            call_args = mock_exec.call_args[0]
+            assert "--plan" in call_args
+
+    @pytest.mark.asyncio
+    async def test_implement_with_context(self) -> None:
+        """Verify implement method prepends context."""
+        config = CLIToolConfig(enabled=True)
+        client = ClaudeCodeClient(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"output", b""))
+        mock_proc.returncode = 0
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
+        ):
+            await client.implement(
+                "Add authentication",
+                context="This is a Python web app",
+            )
+
+            # Verify prompt includes context
+            call_args = mock_exec.call_args[0]
+            prompt_idx = call_args.index("--prompt")
+            prompt = call_args[prompt_idx + 1]
+            assert "This is a Python web app" in prompt
+            assert "Add authentication" in prompt
+
+    @pytest.mark.asyncio
+    async def test_analyze_basic(self) -> None:
+        """Verify analyze method creates correct prompt."""
+        config = CLIToolConfig(enabled=True)
+        client = ClaudeCodeClient(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"output", b""))
+        mock_proc.returncode = 0
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
+        ):
+            await client.analyze("How is auth implemented?")
+
+            call_args = mock_exec.call_args[0]
+            prompt_idx = call_args.index("--prompt")
+            prompt = call_args[prompt_idx + 1]
+            assert "Analyze:" in prompt
+
+    @pytest.mark.asyncio
+    async def test_analyze_with_scope(self) -> None:
+        """Verify analyze method includes scope."""
+        config = CLIToolConfig(enabled=True)
+        client = ClaudeCodeClient(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"output", b""))
+        mock_proc.returncode = 0
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
+        ):
+            await client.analyze("How is auth implemented?", scope="src/auth/")
+
+            call_args = mock_exec.call_args[0]
+            prompt_idx = call_args.index("--prompt")
+            prompt = call_args[prompt_idx + 1]
+            assert "Scope: src/auth/" in prompt
+
+    @pytest.mark.asyncio
+    async def test_test_basic(self) -> None:
+        """Verify test method creates correct prompt."""
+        config = CLIToolConfig(enabled=True)
+        client = ClaudeCodeClient(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"output", b""))
+        mock_proc.returncode = 0
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
+        ):
+            await client.test("tests/unit/")
+
+            call_args = mock_exec.call_args[0]
+            prompt_idx = call_args.index("--prompt")
+            prompt = call_args[prompt_idx + 1]
+            assert "Run tests" in prompt
+            assert "tests/unit/" in prompt
+
+    @pytest.mark.asyncio
+    async def test_test_with_fix_failures(self) -> None:
+        """Verify test method includes fix instruction."""
+        config = CLIToolConfig(enabled=True)
+        client = ClaudeCodeClient(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"output", b""))
+        mock_proc.returncode = 0
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
+        ):
+            await client.test("tests/unit/", fix_failures=True)
+
+            call_args = mock_exec.call_args[0]
+            prompt_idx = call_args.index("--prompt")
+            prompt = call_args[prompt_idx + 1]
+            assert "fix" in prompt.lower()
+
+    @pytest.mark.asyncio
+    async def test_review_basic(self) -> None:
+        """Verify review method creates correct prompt."""
+        config = CLIToolConfig(enabled=True)
+        client = ClaudeCodeClient(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"output", b""))
+        mock_proc.returncode = 0
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
+        ):
+            await client.review("src/tools/")
+
+            call_args = mock_exec.call_args[0]
+            prompt_idx = call_args.index("--prompt")
+            prompt = call_args[prompt_idx + 1]
+            assert "Review:" in prompt
+
+    @pytest.mark.asyncio
+    async def test_review_with_focus(self) -> None:
+        """Verify review method includes focus areas."""
+        config = CLIToolConfig(enabled=True)
+        client = ClaudeCodeClient(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"output", b""))
+        mock_proc.returncode = 0
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
+        ):
+            await client.review("src/tools/", focus="security")
+
+            call_args = mock_exec.call_args[0]
+            prompt_idx = call_args.index("--prompt")
+            prompt = call_args[prompt_idx + 1]
+            assert "Focus on: security" in prompt
+
+    @pytest.mark.asyncio
+    async def test_refactor_basic(self) -> None:
+        """Verify refactor method creates correct prompt."""
+        config = CLIToolConfig(enabled=True)
+        client = ClaudeCodeClient(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"output", b""))
+        mock_proc.returncode = 0
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
+        ):
+            await client.refactor("src/config/loader.py", "Extract validation")
+
+            call_args = mock_exec.call_args[0]
+            prompt_idx = call_args.index("--prompt")
+            prompt = call_args[prompt_idx + 1]
+            assert "Refactor" in prompt
+            assert "src/config/loader.py" in prompt
+            assert "Extract validation" in prompt
+            # Plan mode should be enabled by default
+            assert "--plan" in call_args

--- a/tests/unit/tools/test_registry.py
+++ b/tests/unit/tools/test_registry.py
@@ -1,0 +1,249 @@
+"""Unit tests for tool registry (Issue #17)."""
+
+from __future__ import annotations
+
+import pytest
+
+from yolo_developer.config import CLIToolConfig, ToolsConfig
+from yolo_developer.tools.claude_code import ClaudeCodeClient
+from yolo_developer.tools.registry import ToolRegistry
+
+
+class TestToolRegistry:
+    """Tests for ToolRegistry."""
+
+    def test_init_with_defaults(self) -> None:
+        """Verify registry initialization with default config."""
+        config = ToolsConfig()
+        registry = ToolRegistry(config)
+        assert registry.config == config
+        assert registry.cwd is None
+
+    def test_init_with_cwd(self) -> None:
+        """Verify registry initialization with custom cwd."""
+        config = ToolsConfig()
+        registry = ToolRegistry(config, cwd="/tmp/project")
+        assert registry.cwd == "/tmp/project"
+
+    def test_available_none_enabled(self) -> None:
+        """Verify available returns empty list when no tools enabled."""
+        config = ToolsConfig()
+        registry = ToolRegistry(config)
+        assert registry.available() == []
+
+    def test_available_claude_code_enabled(self) -> None:
+        """Verify available includes claude_code when enabled."""
+        config = ToolsConfig(
+            claude_code=CLIToolConfig(enabled=True),
+        )
+        registry = ToolRegistry(config)
+        assert "claude_code" in registry.available()
+
+    def test_available_aider_enabled(self) -> None:
+        """Verify available includes aider when enabled."""
+        config = ToolsConfig(
+            aider=CLIToolConfig(enabled=True),
+        )
+        registry = ToolRegistry(config)
+        assert "aider" in registry.available()
+
+    def test_available_multiple_enabled(self) -> None:
+        """Verify available includes all enabled tools."""
+        config = ToolsConfig(
+            claude_code=CLIToolConfig(enabled=True),
+            aider=CLIToolConfig(enabled=True),
+        )
+        registry = ToolRegistry(config)
+        available = registry.available()
+        assert "claude_code" in available
+        assert "aider" in available
+
+    def test_is_available_true(self) -> None:
+        """Verify is_available returns True for enabled tool."""
+        config = ToolsConfig(
+            claude_code=CLIToolConfig(enabled=True),
+        )
+        registry = ToolRegistry(config)
+        assert registry.is_available("claude_code") is True
+
+    def test_is_available_false(self) -> None:
+        """Verify is_available returns False for disabled tool."""
+        config = ToolsConfig()
+        registry = ToolRegistry(config)
+        assert registry.is_available("claude_code") is False
+
+    def test_is_available_unknown_tool(self) -> None:
+        """Verify is_available returns False for unknown tool."""
+        config = ToolsConfig()
+        registry = ToolRegistry(config)
+        assert registry.is_available("unknown_tool") is False
+
+
+class TestToolRegistryGet:
+    """Tests for ToolRegistry.get() method."""
+
+    def test_get_disabled_tool_returns_none(self) -> None:
+        """Verify get returns None for disabled tool."""
+        config = ToolsConfig()
+        registry = ToolRegistry(config)
+        assert registry.get("claude_code") is None
+
+    def test_get_unknown_tool_returns_none(self) -> None:
+        """Verify get returns None for unknown tool."""
+        config = ToolsConfig()
+        registry = ToolRegistry(config)
+        assert registry.get("unknown_tool") is None
+
+    def test_get_claude_code_enabled(self) -> None:
+        """Verify get returns ClaudeCodeClient when enabled."""
+        config = ToolsConfig(
+            claude_code=CLIToolConfig(enabled=True),
+        )
+        registry = ToolRegistry(config)
+        tool = registry.get("claude_code")
+        assert tool is not None
+        assert isinstance(tool, ClaudeCodeClient)
+
+    def test_get_caches_instance(self) -> None:
+        """Verify get returns same instance on repeated calls."""
+        config = ToolsConfig(
+            claude_code=CLIToolConfig(enabled=True),
+        )
+        registry = ToolRegistry(config)
+        tool1 = registry.get("claude_code")
+        tool2 = registry.get("claude_code")
+        assert tool1 is tool2
+
+    def test_get_passes_cwd(self) -> None:
+        """Verify get passes cwd to tool client."""
+        config = ToolsConfig(
+            claude_code=CLIToolConfig(enabled=True),
+        )
+        registry = ToolRegistry(config, cwd="/tmp/project")
+        tool = registry.get("claude_code")
+        assert tool is not None
+        assert tool.cwd == "/tmp/project"
+
+
+class TestToolRegistryGetOrRaise:
+    """Tests for ToolRegistry.get_or_raise() method."""
+
+    def test_get_or_raise_disabled_tool(self) -> None:
+        """Verify get_or_raise raises for disabled tool."""
+        config = ToolsConfig()
+        registry = ToolRegistry(config)
+        with pytest.raises(ValueError) as exc_info:
+            registry.get_or_raise("claude_code")
+        assert "claude_code" in str(exc_info.value)
+        assert "not available" in str(exc_info.value)
+
+    def test_get_or_raise_unknown_tool(self) -> None:
+        """Verify get_or_raise raises for unknown tool."""
+        config = ToolsConfig()
+        registry = ToolRegistry(config)
+        with pytest.raises(ValueError) as exc_info:
+            registry.get_or_raise("unknown_tool")
+        assert "unknown_tool" in str(exc_info.value)
+
+    def test_get_or_raise_enabled_tool(self) -> None:
+        """Verify get_or_raise returns tool when enabled."""
+        config = ToolsConfig(
+            claude_code=CLIToolConfig(enabled=True),
+        )
+        registry = ToolRegistry(config)
+        tool = registry.get_or_raise("claude_code")
+        assert isinstance(tool, ClaudeCodeClient)
+
+    def test_get_or_raise_shows_available_tools(self) -> None:
+        """Verify get_or_raise shows available tools in error."""
+        config = ToolsConfig(
+            aider=CLIToolConfig(enabled=True),
+        )
+        registry = ToolRegistry(config)
+        with pytest.raises(ValueError) as exc_info:
+            registry.get_or_raise("claude_code")
+        assert "aider" in str(exc_info.value)
+
+
+class TestToolRegistryContains:
+    """Tests for ToolRegistry.__contains__ method."""
+
+    def test_contains_enabled_tool(self) -> None:
+        """Verify 'in' operator works for enabled tool."""
+        config = ToolsConfig(
+            claude_code=CLIToolConfig(enabled=True),
+        )
+        registry = ToolRegistry(config)
+        assert "claude_code" in registry
+
+    def test_contains_disabled_tool(self) -> None:
+        """Verify 'in' operator works for disabled tool."""
+        config = ToolsConfig()
+        registry = ToolRegistry(config)
+        assert "claude_code" not in registry
+
+
+class TestToolRegistryIteration:
+    """Tests for ToolRegistry iteration."""
+
+    def test_iter_no_tools(self) -> None:
+        """Verify iteration over empty registry."""
+        config = ToolsConfig()
+        registry = ToolRegistry(config)
+        tools = list(registry)
+        assert tools == []
+
+    def test_iter_with_tools(self) -> None:
+        """Verify iteration over registry with tools."""
+        config = ToolsConfig(
+            claude_code=CLIToolConfig(enabled=True),
+            aider=CLIToolConfig(enabled=True),
+        )
+        registry = ToolRegistry(config)
+        tools = list(registry)
+        assert "claude_code" in tools
+        assert "aider" in tools
+
+    def test_iter_in_for_loop(self) -> None:
+        """Verify registry can be used in for loop."""
+        config = ToolsConfig(
+            claude_code=CLIToolConfig(enabled=True),
+        )
+        registry = ToolRegistry(config)
+        count = 0
+        for tool_name in registry:
+            assert tool_name == "claude_code"
+            count += 1
+        assert count == 1
+
+
+class TestToolRegistryModuleExports:
+    """Tests for tools module exports."""
+
+    def test_tool_registry_importable(self) -> None:
+        """Verify ToolRegistry can be imported from tools module."""
+        from yolo_developer.tools import ToolRegistry
+
+        assert ToolRegistry is not None
+
+    def test_claude_code_client_importable(self) -> None:
+        """Verify ClaudeCodeClient can be imported from tools module."""
+        from yolo_developer.tools import ClaudeCodeClient
+
+        assert ClaudeCodeClient is not None
+
+    def test_base_classes_importable(self) -> None:
+        """Verify base classes can be imported from tools module."""
+        from yolo_developer.tools import (
+            BaseCLITool,
+            ToolDisabledError,
+            ToolError,
+            ToolNotFoundError,
+            ToolResult,
+        )
+
+        assert BaseCLITool is not None
+        assert ToolResult is not None
+        assert ToolError is not None
+        assert ToolNotFoundError is not None
+        assert ToolDisabledError is not None


### PR DESCRIPTION
## Summary

Implements Phase 1-4 of Issue #17 - External CLI Tool Integration. This enables YOLO Developer to integrate with external CLI-based AI development tools like Claude Code and Aider.

### What's Included

- **Configuration Schema** - `CLIToolConfig` and `ToolsConfig` with full env var support
- **Base Framework** - `BaseCLITool` abstract class with async subprocess execution
- **Claude Code Client** - Full integration with plan mode, model selection, and convenience methods
- **Tool Registry** - Lazy initialization and tool lookup

### Key Features

- Async subprocess execution with timeout handling
- JSON output parsing
- Error handling with custom exceptions (`ToolNotFoundError`, `ToolDisabledError`)
- Environment variable configuration: `YOLO_TOOLS__CLAUDE_CODE__ENABLED`, etc.

### Files Changed

| File | Description |
|------|-------------|
| `src/yolo_developer/config/schema.py` | Added `CLIToolConfig`, `ToolsConfig` |
| `src/yolo_developer/config/__init__.py` | Export new config classes |
| `src/yolo_developer/tools/` | New package with base, claude_code, registry |
| `tests/unit/tools/` | 72 comprehensive unit tests |
| `tests/unit/config/test_schema.py` | 21 new config tests |

## Test plan

- [x] All 93 new tests pass
- [x] Existing config tests pass (272 total)
- [x] mypy type checking passes
- [x] ruff linting passes

## Usage Example

```python
from yolo_developer.config import load_config
from yolo_developer.tools import ToolRegistry

config = load_config()
registry = ToolRegistry(config.tools)

if "claude_code" in registry:
    claude = registry.get("claude_code")
    result = await claude.implement("Add user authentication")
```

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)