### PR TITLE
feat(tools): add agent integration and CLI tools command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,38 @@ Environment variables use `YOLO_` prefix with `__` as nested delimiter:
 
 API keys (`openai_api_key`, `anthropic_api_key`) are stored as `SecretStr` and **never** included in config exports.
 
+### External CLI Tools Integration
+
+YOLO Developer can delegate tasks to external CLI tools like Claude Code and Aider. Tools are configured in `yolo.yaml`:
+
+```yaml
+tools:
+  claude_code:
+    enabled: true
+    timeout: 300  # seconds
+    output_format: json  # json or text
+    extra_args: []  # additional CLI args
+  aider:
+    enabled: false
+```
+
+Or via environment variables:
+- `YOLO_TOOLS__CLAUDE_CODE__ENABLED=true`
+- `YOLO_TOOLS__CLAUDE_CODE__TIMEOUT=600`
+- `YOLO_TOOLS__AIDER__ENABLED=true`
+
+Check tool status with:
+```bash
+uv run yolo tools           # Show tool availability
+uv run yolo tools status    # Same as above
+uv run yolo tools --json    # JSON output
+```
+
+Tool integration provides:
+- **Security**: Delegated authentication (tools use their own credentials)
+- **Features**: Access to tool-specific capabilities (Claude Code plan mode, MCP client, web search)
+- **Flexibility**: Configure tools independently per project
+
 ### Test Organization
 
 ```

--- a/src/yolo_developer/cli/commands/tools.py
+++ b/src/yolo_developer/cli/commands/tools.py
@@ -1,0 +1,235 @@
+"""YOLO tools command implementation (Issue #17).
+
+This module provides the yolo tools command which manages external CLI tool
+integrations like Claude Code and Aider.
+
+Subcommands:
+- `yolo tools` - Show tool status (default)
+- `yolo tools status` - Show detailed tool status
+
+Examples:
+    yolo tools                  # Show tool status
+    yolo tools status           # Same as above
+    yolo tools status --json    # Output as JSON
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+
+import structlog
+import typer
+from rich.table import Table
+
+from yolo_developer.cli.display import (
+    console,
+    info_panel,
+    warning_panel,
+)
+
+logger = structlog.get_logger(__name__)
+
+# Create the tools subcommand app
+tools_app = typer.Typer(
+    name="tools",
+    help="Manage external CLI tool integrations.",
+    no_args_is_help=False,
+)
+
+
+def _load_tools_config() -> tuple[bool, dict[str, dict[str, object]] | None, str | None]:
+    """Load tools configuration from yolo.yaml.
+
+    Returns:
+        Tuple of (success, config_dict, error_message).
+    """
+    try:
+        from yolo_developer.config import load_config
+
+        config = load_config()
+        tools_config = {
+            "claude_code": {
+                "enabled": config.tools.claude_code.enabled,
+                "path": config.tools.claude_code.path,
+                "timeout": config.tools.claude_code.timeout,
+                "output_format": config.tools.claude_code.output_format,
+            },
+            "aider": {
+                "enabled": config.tools.aider.enabled,
+                "path": config.tools.aider.path,
+                "timeout": config.tools.aider.timeout,
+                "output_format": config.tools.aider.output_format,
+            },
+        }
+        return True, tools_config, None
+    except Exception as e:
+        return False, None, str(e)
+
+
+def _check_tool_availability(tool_name: str, config: dict[str, object]) -> dict[str, object]:
+    """Check if a tool binary is available.
+
+    Args:
+        tool_name: Name of the tool (e.g., "claude_code").
+        config: Tool configuration dict.
+
+    Returns:
+        Dict with availability information.
+    """
+    binary_map = {
+        "claude_code": "claude",
+        "aider": "aider",
+    }
+
+    binary_name = binary_map.get(tool_name, tool_name)
+    custom_path = config.get("path")
+
+    if custom_path:
+        # Check if custom path exists
+        import os
+
+        binary_path = custom_path
+        is_available = os.path.isfile(str(custom_path)) and os.access(str(custom_path), os.X_OK)
+    else:
+        # Check PATH
+        binary_path = shutil.which(binary_name)
+        is_available = binary_path is not None
+
+    return {
+        "binary_name": binary_name,
+        "binary_path": binary_path,
+        "is_available": is_available,
+        "using_custom_path": custom_path is not None,
+    }
+
+
+def show_tools_status(json_output: bool = False) -> None:
+    """Show external CLI tool status.
+
+    Args:
+        json_output: Output as JSON instead of Rich table.
+    """
+    logger.debug("show_tools_status_invoked", json_output=json_output)
+
+    # Load configuration
+    success, tools_config, error = _load_tools_config()
+
+    if not success:
+        if json_output:
+            print(json.dumps({"error": error, "status": "config_error"}))
+        else:
+            warning_panel(
+                f"Could not load configuration: {error}\n\n"
+                "Run 'yolo init' to create a project with configuration.",
+                title="Configuration Error",
+            )
+        raise typer.Exit(code=1)
+
+    assert tools_config is not None  # for type checker
+
+    # Build status info for each tool
+    tools_status: list[dict[str, object]] = []
+
+    for tool_name, config in tools_config.items():
+        availability = _check_tool_availability(tool_name, config)
+
+        status_entry = {
+            "name": tool_name,
+            "enabled": config["enabled"],
+            "binary": availability["binary_name"],
+            "available": availability["is_available"],
+            "path": availability["binary_path"],
+            "timeout": config["timeout"],
+            "output_format": config["output_format"],
+        }
+        tools_status.append(status_entry)
+
+    # Output
+    if json_output:
+        print(json.dumps({"tools": tools_status, "status": "success"}, indent=2))
+    else:
+        _display_tools_table(tools_status)
+
+
+def _display_tools_table(tools_status: list[dict[str, object]]) -> None:
+    """Display tools status as a Rich table.
+
+    Args:
+        tools_status: List of tool status dictionaries.
+    """
+    table = Table(title="External CLI Tools", show_header=True, header_style="bold cyan")
+
+    table.add_column("Tool", style="cyan")
+    table.add_column("Enabled", justify="center")
+    table.add_column("Available", justify="center")
+    table.add_column("Binary")
+    table.add_column("Timeout", justify="right")
+
+    for tool in tools_status:
+        enabled = "[green]Yes[/green]" if tool["enabled"] else "[dim]No[/dim]"
+        available = "[green]Yes[/green]" if tool["available"] else "[red]No[/red]"
+        binary = str(tool["path"]) if tool["path"] else f"[dim]{tool['binary']} (not found)[/dim]"
+        timeout = f"{tool['timeout']}s"
+
+        table.add_row(
+            str(tool["name"]),
+            enabled,
+            available,
+            binary,
+            timeout,
+        )
+
+    console.print(table)
+    console.print()
+
+    # Show summary and hints
+    enabled_tools = [t for t in tools_status if t["enabled"]]
+
+    if not enabled_tools:
+        info_panel(
+            "No tools are enabled. To enable a tool, add to yolo.yaml:\n\n"
+            "  tools:\n"
+            "    claude_code:\n"
+            "      enabled: true\n\n"
+            "Or set environment variable: YOLO_TOOLS__CLAUDE_CODE__ENABLED=true",
+            title="Tip",
+        )
+    elif enabled_tools and not all(t["available"] for t in enabled_tools):
+        missing = [t["name"] for t in enabled_tools if not t["available"]]
+        info_panel(
+            f"Some enabled tools are not installed: {', '.join(missing)}\n\n"
+            "Install the missing tool binaries to use them.",
+            title="Missing Tools",
+        )
+
+
+@tools_app.callback(invoke_without_command=True)
+def tools_callback(
+    ctx: typer.Context,
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        "-j",
+        help="Output as JSON.",
+    ),
+) -> None:
+    """Manage external CLI tool integrations.
+
+    Shows tool status when called without a subcommand.
+    """
+    if ctx.invoked_subcommand is None:
+        show_tools_status(json_output=json_output)
+
+
+@tools_app.command("status")
+def tools_status_command(
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        "-j",
+        help="Output as JSON.",
+    ),
+) -> None:
+    """Show external CLI tool status and availability."""
+    show_tools_status(json_output=json_output)

--- a/src/yolo_developer/cli/main.py
+++ b/src/yolo_developer/cli/main.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import warnings
+from pathlib import Path
 
 import click
 import typer
@@ -17,17 +17,19 @@ warnings.filterwarnings(
 )
 
 import yolo_developer.cli.commands.chat as chat_commands
-from yolo_developer.cli.commands.init import init_command
-from yolo_developer.cli.commands.mcp import app as mcp_app
 from yolo_developer.cli.commands.gather import app as gather_app
 from yolo_developer.cli.commands.git import app as git_app
-from yolo_developer.cli.commands.web import app as web_app
 from yolo_developer.cli.commands.importer import app as import_app
+from yolo_developer.cli.commands.init import init_command
 from yolo_developer.cli.commands.issue import app as issue_app
+from yolo_developer.cli.commands.mcp import app as mcp_app
 from yolo_developer.cli.commands.pr import app as pr_app
 from yolo_developer.cli.commands.release import app as release_app
-from yolo_developer.cli.commands.workflow import app as workflow_app
 from yolo_developer.cli.commands.scan import scan_command
+from yolo_developer.cli.commands.tools import tools_app
+from yolo_developer.cli.commands.web import app as web_app
+from yolo_developer.cli.commands.workflow import app as workflow_app
+
 
 class YoloCLIGroup(TyperGroup):
     """Custom group that treats unknown commands as chat prompts."""
@@ -66,6 +68,7 @@ app.add_typer(workflow_app, name="workflow")
 app.add_typer(import_app, name="import")
 app.add_typer(gather_app, name="gather")
 app.add_typer(web_app, name="web")
+app.add_typer(tools_app, name="tools")
 
 
 @app.callback(invoke_without_command=True)

--- a/src/yolo_developer/orchestrator/state.py
+++ b/src/yolo_developer/orchestrator/state.py
@@ -49,7 +49,7 @@ from langgraph.graph.message import add_messages
 from yolo_developer.orchestrator.context import Decision, HandoffContext
 
 
-class YoloState(TypedDict):
+class YoloState(TypedDict, total=False):
     """Main state for YOLO Developer orchestration.
 
     This TypedDict defines the shape of state passed through the LangGraph
@@ -58,10 +58,13 @@ class YoloState(TypedDict):
 
     Attributes:
         messages: Accumulated messages from all agents. Uses add_messages
-            reducer to append rather than replace.
-        current_agent: Currently executing agent identifier (e.g., "analyst").
+            reducer to append rather than replace. Required.
+        current_agent: Currently executing agent identifier (e.g., "analyst"). Required.
         handoff_context: Context from most recent handoff, or None.
-        decisions: All decisions made during the current sprint.
+        decisions: All decisions made during the current sprint. Required.
+        tool_registry: Registry of external CLI tools (e.g., Claude Code).
+            Optional - when present, agents can delegate tasks to external tools.
+            Type is Any to avoid circular imports (actual type: ToolRegistry).
 
     Example:
         >>> state: YoloState = {
@@ -76,10 +79,15 @@ class YoloState(TypedDict):
         add_messages reducer automatically when state updates are applied.
     """
 
+    # Required fields
     messages: Annotated[list[BaseMessage], add_messages]
     current_agent: str
-    handoff_context: HandoffContext | None
     decisions: list[Decision]
+    # Optional fields
+    handoff_context: HandoffContext | None
+    # Type is Any to avoid circular imports at runtime (LangGraph needs runtime access)
+    # Actual type: yolo_developer.tools.ToolRegistry
+    tool_registry: Any
 
 
 def get_messages_reducer() -> Callable[[list[BaseMessage], list[BaseMessage]], list[BaseMessage]]:

--- a/tests/integration/test_cli_tools.py
+++ b/tests/integration/test_cli_tools.py
@@ -1,0 +1,130 @@
+"""Integration tests for CLI tools command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from yolo_developer.cli.main import app
+
+
+runner = CliRunner()
+
+
+class TestToolsCommand:
+    """Integration tests for yolo tools command."""
+
+    def test_tools_without_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify tools command handles missing config gracefully."""
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["tools"])
+
+        # Should fail gracefully with helpful message
+        assert result.exit_code == 1
+        assert "Configuration Error" in result.output or "config" in result.output.lower()
+
+    def test_tools_status_without_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify tools status command handles missing config gracefully."""
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["tools", "status"])
+
+        assert result.exit_code == 1
+
+    def test_tools_json_output_without_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify tools --json returns error as JSON."""
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["tools", "--json"])
+
+        assert result.exit_code == 1
+        # Should still output valid JSON
+        try:
+            data = json.loads(result.output)
+            assert "error" in data or "status" in data
+        except json.JSONDecodeError:
+            # It's okay if it doesn't output JSON on error
+            pass
+
+
+class TestToolsWithConfig:
+    """Integration tests for tools command with valid config."""
+
+    @pytest.fixture
+    def project_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> Path:
+        """Create a project directory with yolo.yaml config."""
+        config_content = """
+project_name: test-project
+
+tools:
+  claude_code:
+    enabled: true
+    timeout: 300
+  aider:
+    enabled: false
+"""
+        yolo_yaml = tmp_path / "yolo.yaml"
+        yolo_yaml.write_text(config_content)
+        monkeypatch.chdir(tmp_path)
+        return tmp_path
+
+    def test_tools_shows_status(self, project_dir: Path) -> None:
+        """Verify tools command shows tool status table."""
+        result = runner.invoke(app, ["tools"])
+
+        # Should succeed (exit code 0)
+        assert result.exit_code == 0
+        assert "claude_code" in result.output
+        assert "aider" in result.output
+
+    def test_tools_json_output(self, project_dir: Path) -> None:
+        """Verify tools --json returns valid JSON."""
+        result = runner.invoke(app, ["tools", "--json"])
+
+        assert result.exit_code == 0
+
+        # Find JSON object in output (may have log messages before it)
+        output = result.output
+        json_start = output.find("{")
+        assert json_start >= 0, "No JSON object found in output"
+        json_output = output[json_start:]
+
+        data = json.loads(json_output)
+        assert "tools" in data
+        assert "status" in data
+        assert data["status"] == "success"
+
+        # Verify tool entries
+        tools = data["tools"]
+        assert len(tools) == 2
+
+        claude_tool = next(t for t in tools if t["name"] == "claude_code")
+        assert claude_tool["enabled"] is True
+        assert claude_tool["timeout"] == 300
+
+        aider_tool = next(t for t in tools if t["name"] == "aider")
+        assert aider_tool["enabled"] is False
+
+    def test_tools_status_subcommand(self, project_dir: Path) -> None:
+        """Verify tools status subcommand works."""
+        result = runner.invoke(app, ["tools", "status"])
+
+        assert result.exit_code == 0
+        assert "claude_code" in result.output
+
+    def test_tools_help(self) -> None:
+        """Verify tools --help shows usage."""
+        result = runner.invoke(app, ["tools", "--help"])
+
+        assert result.exit_code == 0
+        assert "Manage external CLI tool integrations" in result.output
+        assert "status" in result.output


### PR DESCRIPTION
## Summary

- Add `tool_registry` field to `YoloState` for external tool access during workflow execution
- Add `initialize_tools` parameter to `create_initial_state()` to optionally create tool registry from config
- Create `yolo tools` CLI command with `status` subcommand showing tool availability
- Update CLAUDE.md with external CLI tools configuration documentation

Closes #17 (Phases 5-6)

## Test plan

- [x] Run `uv run pytest tests/unit/tools/` - 72 tests pass
- [x] Run `uv run pytest tests/integration/test_cli_tools.py` - 7 tests pass
- [x] Run `uv run pytest tests/unit/orchestrator/test_workflow.py` - 44 tests pass
- [x] Verify `uv run yolo tools --help` shows usage
- [x] Verify `uv run yolo tools` displays Rich table (requires yolo.yaml)
- [x] Verify `uv run yolo tools --json` outputs valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)