### PR TITLE
feat(cli): add MCP client integration helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Starts an interactive chat session. For one-shot prompts:
 yolo "Summarize the current sprint status"
 ```
 
+Integrate with external AI CLIs (Codex, Claude Code, Cursor, VS Code):
+
+```bash
+yolo integrate claude-code
+```
+
 Full command list:
 
 ```bash

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -67,6 +67,7 @@ yolo "Summarize the current sprint status"
 |:--------|:------------|
 | [`yolo init`](#yolo-init) | Initialize a new YOLO project |
 | [`yolo chat`](#yolo-chat) | Start interactive chat or run one-shot prompts |
+| [`yolo integrate`](#yolo-integrate) | Integrate MCP clients (Codex, Claude Code, Cursor, VS Code) |
 | [`yolo seed`](#yolo-seed) | Seed requirements for development |
 | [`yolo run`](#yolo-run) | Execute autonomous development sprint |
 | [`yolo status`](#yolo-status) | Display current sprint status |
@@ -111,6 +112,37 @@ yolo chat "Summarize the current sprint status"
 **Pipe input:**
 ```bash
 echo "Draft release notes" | yolo chat
+```
+
+---
+
+## yolo integrate
+
+Configure MCP client settings for external AI tools.
+
+### Synopsis
+
+```bash
+yolo integrate <client> [OPTIONS]
+```
+
+### Options
+
+| Option | Description |
+|:-------|:------------|
+| `--config-path, -c` | Override default config path |
+| `--project-dir, -p` | Project directory for `uv run` fallback |
+| `--dry-run` | Show JSON without writing |
+| `--force` | Overwrite existing MCP entry |
+| `--yes, -y` | Skip confirmation prompt |
+
+### Examples
+
+```bash
+yolo integrate claude-code
+yolo integrate codex --dry-run
+yolo integrate cursor --config-path /custom/settings.json --yes
+yolo integrate vscode --force
 ```
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -127,6 +127,18 @@ quality:
 
 ---
 
+## Optional: Integrate with External CLI Tools
+
+Configure MCP clients (Codex CLI, Claude Code, Cursor, VS Code) automatically:
+
+```bash
+uv run yolo integrate claude-code
+```
+
+Use `--dry-run` to preview or `--config-path` to target a custom config file.
+
+---
+
 ## Step 3: Initialize a Project
 
 Navigate to your project directory and initialize:

--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -89,6 +89,19 @@ PY
 
 ## Client Configuration
 
+### Quick Setup (Recommended)
+
+Use the CLI helper to install or update MCP config entries:
+
+```bash
+yolo integrate claude-code
+yolo integrate codex
+yolo integrate cursor
+yolo integrate vscode
+```
+
+Add `--dry-run` to preview changes or `--config-path` to target a custom file.
+
 ### Claude Code / Claude Desktop
 
 Add to your configuration file:

--- a/src/yolo_developer/cli/commands/integrate.py
+++ b/src/yolo_developer/cli/commands/integrate.py
@@ -1,0 +1,237 @@
+"""CLI commands for integrating YOLO MCP with external clients."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import os
+import platform
+import shutil
+from typing import Any, Literal
+
+import click
+import typer
+from typer.core import TyperGroup
+
+from yolo_developer.cli.display import error_panel, info_panel, success_panel, warning_panel
+
+ClientName = Literal["codex", "claude-code", "cursor", "vscode"]
+
+MCP_SERVER_NAME = "yolo-developer"
+DEFAULT_CLAUDE_CONFIG_NAME = "claude_desktop_config.json"
+
+class IntegrateCLIGroup(TyperGroup):
+    """Parse args without treating the client name as a subcommand."""
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        if not args and self.no_args_is_help and not ctx.resilient_parsing:
+            raise click.NoArgsIsHelpError(ctx)
+        rest = click.Command.parse_args(self, ctx, args)
+        if self.chain:
+            ctx._protected_args = rest
+            ctx.args = []
+        elif rest:
+            cmd = self.get_command(ctx, rest[0])
+            if cmd is None:
+                ctx._protected_args = []
+                ctx.args = rest
+                return ctx.args
+            ctx._protected_args, ctx.args = rest[:1], rest[1:]
+        return ctx.args
+
+
+app = typer.Typer(
+    name="integrate",
+    help="Integrate YOLO MCP with external clients",
+    invoke_without_command=True,
+    cls=IntegrateCLIGroup,
+    context_settings={"allow_interspersed_args": True},
+)
+
+
+def _default_config_paths(
+    client: ClientName,
+    *,
+    system: str | None = None,
+    home: Path | None = None,
+    appdata: Path | None = None,
+) -> list[Path]:
+    system_name = (system or platform.system()).lower()
+    home_dir = home or Path.home()
+    appdata_dir = appdata or Path(os.environ.get("APPDATA", home_dir))
+
+    if client == "claude-code":
+        if system_name == "darwin":
+            return [home_dir / ".claude" / DEFAULT_CLAUDE_CONFIG_NAME]
+        if system_name == "windows":
+            return [appdata_dir / "Claude" / DEFAULT_CLAUDE_CONFIG_NAME]
+        return [home_dir / ".config" / "Claude" / DEFAULT_CLAUDE_CONFIG_NAME]
+
+    if client == "codex":
+        if system_name == "windows":
+            return [appdata_dir / "Codex" / "config.json"]
+        return [
+            home_dir / ".codex" / "config.json",
+            home_dir / ".config" / "codex" / "config.json",
+        ]
+
+    if client == "cursor":
+        if system_name == "darwin":
+            return [home_dir / "Library" / "Application Support" / "Cursor" / "User" / "settings.json"]
+        if system_name == "windows":
+            return [appdata_dir / "Cursor" / "User" / "settings.json"]
+        return [home_dir / ".config" / "Cursor" / "User" / "settings.json"]
+
+    if client == "vscode":
+        if system_name == "darwin":
+            return [home_dir / "Library" / "Application Support" / "Code" / "User" / "settings.json"]
+        if system_name == "windows":
+            return [appdata_dir / "Code" / "User" / "settings.json"]
+        return [home_dir / ".config" / "Code" / "User" / "settings.json"]
+
+    raise ValueError(f"Unsupported client: {client}")
+
+
+def _resolve_config_path(client: ClientName, config_path: Path | None) -> Path:
+    if config_path is not None:
+        return config_path
+    candidates = _default_config_paths(client)
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
+def _resolve_mcp_command(project_dir: Path) -> tuple[str, list[str], str | None]:
+    yolo_mcp = shutil.which("yolo-mcp")
+    if yolo_mcp:
+        return yolo_mcp, [], None
+    uv = shutil.which("uv")
+    if uv:
+        return uv, ["run", "--directory", str(project_dir), "yolo-mcp"], str(project_dir)
+    raise RuntimeError("Neither `yolo-mcp` nor `uv` was found on PATH.")
+
+
+def _load_config(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    content = path.read_text(encoding="utf-8").strip()
+    if not content:
+        return {}
+    data = json.loads(content)
+    if not isinstance(data, dict):
+        raise ValueError(f"Config file must contain a JSON object: {path}")
+    return data
+
+
+def _apply_mcp_entry(
+    config: dict[str, Any],
+    entry: dict[str, Any],
+    *,
+    force: bool,
+) -> tuple[dict[str, Any], bool]:
+    mcp_servers = config.get("mcpServers")
+    if mcp_servers is None:
+        mcp_servers = {}
+    if not isinstance(mcp_servers, dict):
+        raise ValueError("Existing mcpServers entry must be a JSON object.")
+    existing = mcp_servers.get(MCP_SERVER_NAME)
+    if existing is not None and not force and existing != entry:
+        raise ValueError(
+            f"mcpServers.{MCP_SERVER_NAME} already exists. Use --force to overwrite."
+        )
+    if existing == entry:
+        config["mcpServers"] = mcp_servers
+        return config, False
+    mcp_servers[MCP_SERVER_NAME] = entry
+    config["mcpServers"] = mcp_servers
+    return config, True
+
+
+def _write_config(path: Path, config: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+
+
+@app.callback()
+def integrate(
+    client: ClientName = typer.Argument(..., help="Client to integrate."),
+    config_path: Path | None = typer.Option(
+        None,
+        "--config-path",
+        "-c",
+        help="Override default config path.",
+    ),
+    project_dir: Path | None = typer.Option(
+        None,
+        "--project-dir",
+        "-p",
+        help="Project directory to use for `uv run` fallback.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show resulting JSON without writing.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Overwrite existing MCP entry.",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompt.",
+    ),
+) -> None:
+    """Integrate YOLO MCP server with a CLI client configuration."""
+    path = _resolve_config_path(client, config_path)
+    effective_project_dir = project_dir or Path.cwd()
+    try:
+        command, args, cwd = _resolve_mcp_command(effective_project_dir)
+    except RuntimeError as exc:
+        error_panel(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    entry: dict[str, Any] = {"command": command, "args": args}
+    if cwd is not None:
+        entry["cwd"] = cwd
+
+    try:
+        config = _load_config(path)
+        updated, changed = _apply_mcp_entry(config, entry, force=force)
+    except (ValueError, json.JSONDecodeError) as exc:
+        error_panel(str(exc))
+        raise typer.Exit(code=1) from exc
+
+    if dry_run:
+        info_panel(f"Dry run: {path}")
+        typer.echo(json.dumps(updated, indent=2))
+        return
+
+    if not yes:
+        confirm = typer.confirm(f"Update {path} with YOLO MCP entry?", default=True)
+        if not confirm:
+            warning_panel("Aborted.")
+            raise typer.Exit(code=1)
+
+    _write_config(path, updated)
+
+    if changed:
+        success_panel(f"Updated {path}")
+    else:
+        info_panel(f"No changes needed in {path}")
+    typer.echo("Restart your client and re-open MCP tools to load YOLO.")
+
+
+__all__ = [
+    "ClientName",
+    "DEFAULT_CLAUDE_CONFIG_NAME",
+    "MCP_SERVER_NAME",
+    "_apply_mcp_entry",
+    "_default_config_paths",
+    "_load_config",
+    "_resolve_config_path",
+    "_resolve_mcp_command",
+]

--- a/src/yolo_developer/cli/commands/mcp.py
+++ b/src/yolo_developer/cli/commands/mcp.py
@@ -15,11 +15,13 @@ from typing import Literal
 
 import typer
 
+from yolo_developer.cli.commands.integrate import app as integrate_app
 from yolo_developer.mcp.server import TransportType, run_server
 
 # Create a Typer app for the mcp command
 # This allows it to be registered as a subcommand
 app = typer.Typer(help="MCP server commands")
+app.add_typer(integrate_app, name="integrate")
 
 
 def mcp_command(

--- a/src/yolo_developer/cli/main.py
+++ b/src/yolo_developer/cli/main.py
@@ -17,6 +17,7 @@ warnings.filterwarnings(
 )
 
 import yolo_developer.cli.commands.chat as chat_commands
+from yolo_developer.cli.commands.integrate import app as integrate_app
 from yolo_developer.cli.commands.gather import app as gather_app
 from yolo_developer.cli.commands.git import app as git_app
 from yolo_developer.cli.commands.importer import app as import_app
@@ -68,6 +69,7 @@ app.add_typer(workflow_app, name="workflow")
 app.add_typer(import_app, name="import")
 app.add_typer(gather_app, name="gather")
 app.add_typer(web_app, name="web")
+app.add_typer(integrate_app, name="integrate")
 app.add_typer(tools_app, name="tools")
 
 

--- a/tests/unit/cli/test_integrate_command.py
+++ b/tests/unit/cli/test_integrate_command.py
@@ -1,0 +1,103 @@
+"""Tests for MCP integration CLI helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from typer.testing import CliRunner
+
+from yolo_developer.cli.commands import integrate as integrate_commands
+
+runner = CliRunner()
+
+
+def test_default_paths_claude_macos(tmp_path: Path) -> None:
+    paths = integrate_commands._default_config_paths(
+        "claude-code",
+        system="Darwin",
+        home=tmp_path,
+    )
+
+    assert paths == [tmp_path / ".claude" / integrate_commands.DEFAULT_CLAUDE_CONFIG_NAME]
+
+
+def test_default_paths_codex_windows(tmp_path: Path) -> None:
+    appdata = tmp_path / "AppData" / "Roaming"
+    paths = integrate_commands._default_config_paths(
+        "codex",
+        system="Windows",
+        home=tmp_path,
+        appdata=appdata,
+    )
+
+    assert paths == [appdata / "Codex" / "config.json"]
+
+
+def test_resolve_config_path_prefers_existing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    second.write_text("{}", encoding="utf-8")
+
+    def fake_paths(_client: integrate_commands.ClientName) -> list[Path]:
+        return [first, second]
+
+    monkeypatch.setattr(integrate_commands, "_default_config_paths", fake_paths)
+
+    resolved = integrate_commands._resolve_config_path("codex", None)
+
+    assert resolved == second
+
+
+def test_apply_mcp_entry_adds_entry() -> None:
+    config = {}
+    entry = {"command": "yolo-mcp", "args": []}
+
+    updated, changed = integrate_commands._apply_mcp_entry(config, entry, force=False)
+
+    assert changed is True
+    assert updated["mcpServers"][integrate_commands.MCP_SERVER_NAME] == entry
+
+
+def test_apply_mcp_entry_no_change_when_same() -> None:
+    entry = {"command": "yolo-mcp", "args": []}
+    config = {"mcpServers": {integrate_commands.MCP_SERVER_NAME: entry}}
+
+    updated, changed = integrate_commands._apply_mcp_entry(config, entry, force=False)
+
+    assert changed is False
+    assert updated["mcpServers"][integrate_commands.MCP_SERVER_NAME] == entry
+
+
+def test_apply_mcp_entry_requires_force_for_overwrite() -> None:
+    config = {"mcpServers": {integrate_commands.MCP_SERVER_NAME: {"command": "old"}}}
+    entry = {"command": "yolo-mcp", "args": []}
+
+    with pytest.raises(ValueError, match="already exists"):
+        integrate_commands._apply_mcp_entry(config, entry, force=False)
+
+
+def test_integrate_dry_run_does_not_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "settings.json"
+
+    def fake_mcp_command(_project_dir: Path) -> tuple[str, list[str], str | None]:
+        return "yolo-mcp", [], None
+
+    monkeypatch.setattr(integrate_commands, "_resolve_mcp_command", fake_mcp_command)
+
+    result = runner.invoke(
+        integrate_commands.app,
+        [
+            "codex",
+            "--config-path",
+            str(config_path),
+            "--dry-run",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert not config_path.exists()

--- a/tests/unit/cli/test_main_commands.py
+++ b/tests/unit/cli/test_main_commands.py
@@ -166,6 +166,7 @@ class TestAppCommands:
 
         # Commands registered as groups (sub-apps)
         expected_groups = ["config"]
+        expected_groups.append("integrate")
         for grp in expected_groups:
             assert grp in group_names, f"Command group '{grp}' not registered"
 
@@ -175,7 +176,18 @@ class TestAppCommands:
 
         assert result.exit_code == 0
         # Check all commands appear in help
-        for cmd in ["chat", "init", "version", "seed", "run", "status", "logs", "tune", "config"]:
+        for cmd in [
+            "chat",
+            "init",
+            "version",
+            "seed",
+            "run",
+            "status",
+            "logs",
+            "tune",
+            "config",
+            "integrate",
+        ]:
             assert cmd in result.output
 
 


### PR DESCRIPTION
## Summary
- add `yolo integrate` CLI helpers for Codex/Claude Code/Cursor/VS Code MCP config updates
- include path discovery, MCP entry patching, dry-run/force/yes options, uv fallback
- update docs and CLI reference
- add unit tests for config resolution and merge behavior

## Testing
- `uv run pytest tests/unit/cli/test_integrate_command.py tests/unit/cli/test_main_commands.py`

Closes #18
