### PR TITLE
feat(init): add git repository discovery and creation (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,27 @@ Starts an interactive chat session. For one-shot prompts:
 yolo "Summarize the current sprint status"
 ```
 
+### Project Initialization
+
+Create a new YOLO project with `yolo init`:
+
+```bash
+yolo init my-project
+```
+
+The init command automatically:
+- Detects existing git repositories
+- Offers to initialize git if not present
+- Displays remote repository status
+- Creates GitHub repositories via `gh` CLI (if available)
+- Creates an initial commit with project files
+- Pushes to remote if configured
+
+Options:
+- `--skip-git` - Skip git repository prompts
+- `--skip-github` - Skip GitHub repository creation prompts
+- `--no-input` - Use all defaults without prompting
+
 ### External Tool Integration
 
 YOLO can delegate tasks to external CLI tools like Claude Code and Aider for enhanced capabilities:

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -171,6 +171,19 @@ yolo init [OPTIONS] [PATH]
 | `--scan-only` | FLAG | False | Scan existing project without changes |
 | `--non-interactive` | FLAG | False | Skip brownfield prompts |
 | `--hint` | TEXT | None | Hint about project type |
+| `--skip-git` | FLAG | False | Skip git repository prompts |
+| `--skip-github` | FLAG | False | Skip GitHub repository creation prompts |
+
+### Git Repository Features
+
+The init command automatically handles git repository setup:
+
+1. **Detection**: Checks if directory is a git repository
+2. **Initialization**: Offers to run `git init` if not initialized
+3. **Remote Detection**: Displays configured remote repositories
+4. **GitHub Creation**: Creates a new GitHub repository via `gh` CLI (if available)
+5. **Initial Commit**: Creates an initial commit with project files
+6. **Push**: Pushes initial commit to remote repository
 
 ### Examples
 
@@ -187,12 +200,47 @@ Initializing YOLO Developer project...
 ? Author name: Developer
 ? Author email: dev@example.com
 
+This directory is not a git repository. Initialize git? [Y/n] y
+Git repository initialized!
+
+           Git Repository Status
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┓
+┃ Property     ┃ Value               ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━┩
+│ Git Status   │ Initialized         │
+│ Remotes      │ None configured     │
+└──────────────┴─────────────────────┘
+
+Remote Repository Options:
+  1. Create a new GitHub repository
+  2. Add an existing remote URL
+  3. Skip remote setup
+Choose an option [3]:
+
 Creating configuration...
   ✓ Created yolo.yaml
   ✓ Created .yolo/ directory
   ✓ Initialized memory store
 
+Create initial commit with project files? [Y/n] y
+Initial commit created!
+
 Project initialized successfully!
+```
+
+**Skip git prompts:**
+```bash
+yolo init --skip-git
+```
+
+**Skip GitHub prompts only:**
+```bash
+yolo init --skip-github
+```
+
+**Fully automated (no prompts):**
+```bash
+yolo init --no-input
 ```
 
 **Brownfield initialization:**

--- a/src/yolo_developer/cli/main.py
+++ b/src/yolo_developer/cli/main.py
@@ -151,6 +151,16 @@ def init(
         "--hint",
         help="Hint about project type (e.g., 'fastapi api').",
     ),
+    skip_git: bool = typer.Option(
+        False,
+        "--skip-git",
+        help="Skip git repository initialization prompts.",
+    ),
+    skip_github: bool = typer.Option(
+        False,
+        "--skip-github",
+        help="Skip GitHub repository creation prompts.",
+    ),
 ) -> None:
     """Initialize a new YOLO Developer project.
 
@@ -176,6 +186,8 @@ def init(
         scan_only=scan_only,
         non_interactive=non_interactive,
         hint=hint,
+        skip_git=skip_git,
+        skip_github=skip_github,
     )
 
 


### PR DESCRIPTION
## Summary
- Add git repository detection and initialization during `yolo init`
- Add GitHub repository creation via `gh` CLI integration
- Add initial commit and push functionality with user prompts
- Add `--skip-git` and `--skip-github` CLI options for automation
- Update documentation with new features

## Changes

### Git Detection & Initialization
- `check_git_initialized()` - Detects if directory is a git repository
- `get_git_remotes()` - Gets configured remote repositories
- `init_git_repository()` - Initializes git with comprehensive `.gitignore`
- `display_git_status()` - Rich table showing git status

### GitHub Integration
- `check_gh_cli_available()` - Checks for `gh` CLI
- `check_gh_authenticated()` - Checks `gh` authentication
- `create_github_repo()` - Creates GitHub repo via `gh` CLI
- Menu with options: create GitHub repo, add existing URL, or skip

### Commit & Push
- `create_initial_commit()` - Stages and commits project files
- `push_to_remote()` - Pushes to remote with upstream tracking

### CLI Options
- `--skip-git` - Skip git repository initialization prompts
- `--skip-github` - Skip GitHub repository creation prompts

## Test plan
- [x] All 78 new unit tests pass
- [x] Existing tests continue to pass (85 total)
- [x] Manual testing of interactive prompts

Closes #21

🤖 Generated with [Claude Code](https://claude.ai/claude-code)